### PR TITLE
v3.12.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "micropad",
-	"version": "3.12.3",
+	"version": "3.12.4",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/MicroPad/Web.git"

--- a/app/src/epics/NoteEpics.ts
+++ b/app/src/epics/NoteEpics.ts
@@ -158,7 +158,9 @@ const quickMarkdownInsert$ = (action$: Observable<Action<void>>, store: Store<IS
 		filter(ref => ref.length > 0 && !!store.getState().notepads.notepad && !!store.getState().notepads.notepad!.item),
 		map(ref => store.getState().notepads.notepad!.item!.notes[ref]),
 		concatMap(note => {
-			const id = `markdown${note.elements.filter(e => e.type === 'markdown').length + 1}`;
+			let count = note.elements.filter(e => e.type === 'markdown').length + 1;
+			let id = `markdown${count}`;
+			while (note.elements.some(e => e.args.id === id)) id = `markdown${++count}`;
 
 			return [
 				actions.insertElement({

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -156,7 +156,7 @@ async function compatibilityCheck(): Promise<boolean> {
 					Try with a more modern browser like <a href="https://www.google.com/chrome/" target="_blank" rel="nofollow noreferrer">Google Chrome</a> or <a href="https://www.mozilla.org/firefox/" target="_blank" rel="nofollow noreferrer">Mozilla Firefox</a>.
 				</p>
 				<p>
-					You can always use the old {APP_NAME} <a href="https://getmicropad.com/web">here</a>.
+					You can always get the downloadable version of {APP_NAME} <a href="https://getmicropad.com/#download">here</a>.
 				</p>
 			</div>,
 			document.getElementById('app') as HTMLElement


### PR DESCRIPTION
- Fixed an issue with quick-insertion on legacy notes
- Changed the unsupported link to the electron app