### PR TITLE
v3.19.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "micropad",
-	"version": "3.19.2",
+	"version": "3.19.3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/MicroPad/Web.git"
@@ -58,7 +58,7 @@
 		"semver": "^5.6.0",
 		"showdown": "^1.8.6",
 		"twemoji": "^11.0.1",
-		"upad-parse": "^6.2.0",
+		"upad-parse": "^6.2.2",
 		"vex-dialog": "^1.1.0",
 		"vex-js": "^4.1.0"
 	},

--- a/app/src/core/reducers/AppReducer.ts
+++ b/app/src/core/reducers/AppReducer.ts
@@ -34,7 +34,7 @@ export class AppReducer extends MicroPadReducer<IAppStoreState> {
 			major,
 			minor,
 			patch,
-			status: isDev() ? 'dev' : 'beta'
+			status: isDev() ? 'dev' : 'stable'
 		},
 		isFullScreen: false,
 		defaultFontSize: '16px',

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2528,7 +2528,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.29.0:
+date-fns@^1.29.0, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -9223,13 +9223,13 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
 
-upad-parse@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/upad-parse/-/upad-parse-6.2.0.tgz#f35ed5edbf9aa6613133950fded6001b6a65b179"
-  integrity sha512-LhdKBEVBtqJLSE9fH+pGLp/fcLET/irXwS2izRbe+e73sYowYH8s0glcj7vN5TuYAolhJ7BdLJVjknu2AADB3w==
+upad-parse@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/upad-parse/-/upad-parse-6.2.2.tgz#3e46c3e4cfea6ed3a6b95e2e2720ec2a52f05f61"
+  integrity sha512-KSimjOLxY59FS5J5e8f0IZVekpgpKz29xR5LP8y4RiC+Kz2uv7IBvRv3qfeqSYJmH6Nyd9QCXhVRG/zY9o/keA==
   dependencies:
     aes-js "^3.1.2"
-    date-fns "^1.29.0"
+    date-fns "^1.30.1"
     json-stringify-safe "^5.0.1"
     lz-string "^1.4.4"
     pretty-data "^0.40.0"


### PR DESCRIPTION
- Pulled in the latest parser which should make Evernote imports work even better
- Removed the 'beta' label. I've been meaning to do it for a while, but today is tomorrow's yesterday.