### PR TITLE
Markdown editor improvements

### DIFF
--- a/app/src/react-web/components/note-viewer/elements/NoteElementComponent.tsx
+++ b/app/src/react-web/components/note-viewer/elements/NoteElementComponent.tsx
@@ -60,7 +60,7 @@ export default class NoteElementComponent extends React.Component<INoteElementCo
 					search={search!} />
 				);
 				break;
-				
+
 			case 'image':
 				elementComponent = (
 					<ImageElementComponent
@@ -154,7 +154,7 @@ export default class NoteElementComponent extends React.Component<INoteElementCo
 								</Row>
 
 								<Row style={{ paddingLeft: '5px' }}>
-									<Button className="btn-flat" waves="light" onClick={() => edit('')} style={{marginRight: '5px', float: 'right'}}>Close (autosaved)</Button>
+									<Button className="btn-flat" waves="light" onClick={() => edit('')} style={{marginRight: '5px', float: 'right'}}>Close editor (autosaved)</Button>
 								</Row>
 							</div>
 						}

--- a/app/src/react-web/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
+++ b/app/src/react-web/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
@@ -66,11 +66,23 @@ export default class MarkdownElementComponent extends React.Component<IMarkdownE
 
 		const isEditing = elementEditing === element.args.id;
 
+		const numericSizes = {
+			width: parseInt(element.args.width || '', 10),
+			height: parseInt(element.args.height || '', 10)
+		};
+
+		if (isNaN(numericSizes.width)) numericSizes.width = -1;
+		if (isNaN(numericSizes.height)) numericSizes.height = -1;
+
+		const minWidth = isEditing ? Math.max(400, numericSizes.width) : Math.max(170, numericSizes.width);
+		const width = isEditing ? 'auto' : element.args.width!;
+		const height = isEditing ? 'auto' : element.args.height!;
+
 		return (
 			<Resizable
 				style={{overflow: 'hidden'}}
-				size={{ width: element.args.width!, height: element.args.height! }}
-				minWidth={(isEditing) ? 300 : 170}
+				size={{ width, height }}
+				minWidth={minWidth}
 				enable={{
 					top: false,
 					bottom: false,
@@ -130,11 +142,13 @@ export default class MarkdownElementComponent extends React.Component<IMarkdownE
 						<textarea
 							style={
 								{
+									minWidth,
 									height: '400px',
 									backgroundColor: theme.background,
 									color: theme.text,
-									maxWidth: '100%',
-									minWidth: (element.args.width !== 'auto') ? '100%' : '400px'
+									whiteSpace: 'pre',
+									overflowWrap: 'normal',
+									overflowX: 'scroll'
 								}
 							}
 							ref={input => this.editBox = input!}

--- a/app/src/react-web/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
+++ b/app/src/react-web/components/note-viewer/elements/markdown/MarkdownElementComponent.tsx
@@ -6,7 +6,8 @@ import { IAppWindow, UNSUPPORTED_MESSAGE } from '../../../../../core/types';
 import { enableTabs } from './enable-tabs';
 import TodoListComponent from './TodoListComponent';
 import { debounce } from '../../../../util';
-import { Col, Input, Row } from 'react-materialize';
+import Grid from '@material-ui/core/Grid';
+import { Input } from 'react-materialize';
 import MarkdownHelpComponent from './MarkdownHelpComponent';
 import Resizable from 're-resizable';
 import { Dialog } from '../../../../dialogs';
@@ -104,24 +105,24 @@ export default class MarkdownElementComponent extends React.Component<IMarkdownE
 
 				{
 					isEditing &&
-					<Row style={{ marginBottom: 0, color: theme.text }}>
-						<Col s={6}>
+					<Grid style={{ paddingLeft: '5px', paddingRight: '5px', marginBottom: 0, color: theme.text }} container={true} spacing={3}>
+						<Grid item={true} xs={6}>
 							<Input
 								label="Font Size"
 								defaultValue={element.args.fontSize}
 								onChange={this.onFontSizeEdit}
 							/>
-						</Col>
+						</Grid>
 
-						<Col s={6}>
+						<Grid item={true} xs={6}>
 							<Input
 								style={{ width: '100%', color: theme.text }}
 								label="Width"
 								defaultValue={element.args.width}
 								onChange={(e, v) => this.onSizeEdit('width', v)}
 							/>
-						</Col>
-					</Row>
+						</Grid>
+					</Grid>
 				}
 
 				{isEditing && <span id="markdown-editor-label" style={{ color: theme.text }}>Markdown Editor (<MarkdownHelpComponent />)</span>}

--- a/app/src/react-web/index.tsx
+++ b/app/src/react-web/index.tsx
@@ -1,8 +1,6 @@
 /* CSS Imports */
 import 'material-icons-font/material-icons-font.css';
 import 'materialize-css/dist/css/materialize.min.css'; // TODO: Roboto will need to be imported here when this isn't
-import 'jquery/dist/jquery.slim.js'; // TODO: Yeet this when Materialize is removed
-import 'materialize-css/dist/js/materialize.js';
 import './index.css';
 
 /* Themes */
@@ -14,6 +12,8 @@ import './theme-styles/Purple.css';
 
 /* JS Imports */
 import * as React from 'react';
+import 'jquery/dist/jquery.slim.js'; // TODO: Yeet this when Materialize is removed
+import 'materialize-css/dist/js/materialize.js';
 import registerServiceWorker from './registerServiceWorker';
 import { APP_NAME, IAppWindow, IStoreState, MICROPAD_URL } from '../core/types';
 import { applyMiddleware, createStore } from 'redux';


### PR DESCRIPTION
- Turn off word wrap
- Allow resizing the editor for non-auto elements
- Take out some old Materialize code